### PR TITLE
Make gradle file compatible with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,17 +25,19 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    if (project.android.hasProperty('namespace')) { 
+        namespace 'com.byneapp.flutter_config'
+    }
 
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+    compileSdkVersion 30
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
-    defaultConfig {
-        minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    lintOptions {
-        disable 'InvalidPackage'
+
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.byneapp.flutter_config'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.10'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:8.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -29,7 +29,7 @@ android {
         namespace 'com.byneapp.flutter_config'
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -69,6 +69,10 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
 loadDotEnv()
 
 android {
+    if (project.android.hasProperty('namespace')) { 
+        namespace 'com.byneapp.flutter_config'
+    }
+
     defaultConfig {
         project.env.each { k, v ->
             def escaped = v.replaceAll("%", "\\\\u0025")

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip


### PR DESCRIPTION
This dependency is used by `platform_client`. I updated this so that it works with Flutter 3.22 and AGP 8. The relevant `platform_client` PR is here https://github.com/Flyclops/platform_client/pull/2554